### PR TITLE
Include Virtualenvs in pyenv list of versions

### DIFF
--- a/pyenv-mode.el
+++ b/pyenv-mode.el
@@ -54,8 +54,9 @@
 
 (defun pyenv-mode-versions ()
   "List installed python versions."
-  (let ((versions (shell-command-to-string "pyenv versions --bare")))
-    (cons "system" (split-string versions))))
+  (let ((versions (concat (shell-command-to-string "pyenv versions --bare")
+                          (shell-command-to-string "pyenv virtualenvs --bare"))))
+    (delete-dups (cons "system" (split-string versions)))))
 
 (defun pyenv-mode-read-version ()
   "Read virtual environment from user input."


### PR DESCRIPTION
Anaconda environments are not included in the call to
`pyenv versions --bare` so we also call `pyenv virtualenvs --bare`.

This introduces some duplicates in the list of versions which have to be
removed.

Related issue #15