### PR TITLE
One customize group

### DIFF
--- a/pyenv-mode.el
+++ b/pyenv-mode.el
@@ -28,7 +28,7 @@
 
 (require 'pythonic)
 
-(defgroup pyenv-mode nil
+(defgroup pyenv nil
   "Pyenv virtualenv integration with python mode."
   :group 'languages)
 
@@ -37,7 +37,7 @@
     (when (pyenv-mode-version)
       (concat "Pyenv:" (pyenv-mode-version) " ")))
   "How `pyenv-mode' will indicate the current python version in the mode line."
-  :group 'pyenv-mode)
+  :group 'pyenv)
 
 (defun pyenv-mode-version ()
   "Return currently active pyenv version."


### PR DESCRIPTION
`define-minor-mode` by default connects to a group [without the trailing `-mode`](http://www.gnu.org/software/emacs/manual/html_node/elisp/Defining-Minor-Modes.html), so if you define yet another group called `pyenv-mode`, you will have created 2 customize groups for the same package. This fixes the issue.