### PR TITLE
Is it possible to make pyenv-mode  buffer-local ? 

### DIFF
--- a/pyenv-mode.el
+++ b/pyenv-mode.el
@@ -89,7 +89,6 @@
   "Minor mode for pyenv interaction.
 
 \\{pyenv-mode-map}"
-  :global t
   :lighter ""
   :keymap pyenv-mode-map
   (if pyenv-mode


### PR DESCRIPTION
I add pyenv-mode to python-mode-hook, it's very useful, thanks！ 
But I find a little problem: after editting a .py file, the keybinding "C-c C-s" conflicts with orgmode's org-schedule while orgmode(and others except python-mode) hardly ever needs a pyenv-mode minior mode, so is it possible to make pyenv-mode  buffer-local？ thank you!
